### PR TITLE
Fix some typos in `README.md`

### DIFF
--- a/prompt_translation/README.md
+++ b/prompt_translation/README.md
@@ -8,7 +8,7 @@ The community has created a dataset of 10k prompts [DIBT/10k_prompts_ranked](htt
 
 From this dataset, we have curated a subset of 500 high-quality prompts that cover a diverse range of capabilities for a model, such as math, coding, relationships, email generation, etc.
 
-We want to use these 500 prompts to evaluate the performance of models using [AlpaceEval](https://github.com/tatsu-lab/alpaca_eval) (an automated way of evaluating the performance of instruction/chat models).
+We want to use these 500 prompts to evaluate the performance of models using [AlpacaEval](https://github.com/tatsu-lab/alpaca_eval) (an automated way of evaluating the performance of instruction/chat models).
 
 Currently, our prompts are in English. We are asking the community to help us translate this curated prompt dataset into different languages so that we can use these translated prompts to evaluate the performance of models for the languages we translate into.
 
@@ -25,7 +25,7 @@ There are two ways to contribute to this effort:
 
 This doesn’t mean you need to be fully responsible for everything! It does let us know that at least one person wants to work for a particular language. Once we know someone wants to work on a language task, we’ll help you create an annotation task for that language.
 
-To nominate yourself as a language lead please join our  and let us know which language you want to work on (please tag `@dvs13`) and let us know your Hugging Face username.
+To nominate yourself as a language lead please join our [Discord channel](https://discord.gg/hugging-face-879548962464493619) and let us know which language you want to work on (please tag `@dvs13`) and let us know your Hugging Face username.
 
 #### Setup a Hub organization and create an Argilla Space for your language
 
@@ -37,7 +37,7 @@ Once an Argilla Space is created, anyone with a Hugging Face login can log in to
 
 ### Contribute to the translation of prompts
 
-If there is an existing Argilla effort focused on a language you speak, you can contribute to the translation of prompts. You will just need a Hugging Face account to login to the relevant Space. We will add current efforts for translation to this README as they are launched! The best way to keep up to date is to join the [Discord channel](https://discord.gg/hugging-face-879548962464493619)
+If there is an existing Argilla effort focused on a language you speak, you can contribute to the translation of prompts. You will just need a Hugging Face account to log in to the relevant Space. We will add current efforts for translation to this README as they are launched! The best way to keep up to date is to join the [Discord channel](https://discord.gg/hugging-face-879548962464493619)
 
 ### Submit your translations
 


### PR DESCRIPTION
## Description

This PR fixes some typos as `AlpaceEval` -> `AlpacaEval`, and adds a missing reference to the Discord channel.

Thanks @davanstrien! 🤗