### PR TITLE
add-russian-dibt-lini-and-fix-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ There are not enough language-specific benchmarks for open LLMs! We want to crea
 *Want to contribute translations?* currently, these translation efforts are underway:
 
 - [Dutch](https://dibt-dutch-prompt-translation-for-dutch.hf.space)
+- [Russian](https://dibt-russian-prompt-translation-for-russian.hf.space)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Our first DIBT activity is focused on ranking the quality of prompts. We have al
 
 There are not enough language-specific benchmarks for open LLMs! We want to create a leaderboard for more languages by leveraging the community! You can find more information about this project in the [MPEP README](prompt_translation/README.md).
 
-*Want to contribute translations?* currently, these translation efforts are underway:
+*Want to contribute translations?* Currently, these translation efforts are underway:
 
 - [Dutch](https://dibt-dutch-prompt-translation-for-dutch.hf.space)
 - [Russian](https://dibt-russian-prompt-translation-for-russian.hf.space)

--- a/prompt_translation/setup_prompt_translation_space.ipynb
+++ b/prompt_translation/setup_prompt_translation_space.ipynb
@@ -91,7 +91,7 @@
       "source": [
         "## 1. Create a new organization for your language effort\n",
         "\n",
-        "To make it easier to keep track of your language effort, we recommend creating a new organization for your language effort. This will allow you to keep all of your language effort data in one place. We suggest naming this organization \"DIBT-<language>\" where <language> is the name of your language. For example, if you are working on the language \"Spanish\", you would name your organization \"DIBT-Spanish\". This will make it easier for us to track all of the DIBT language efforts.\n",
+        "To make it easier to keep track of your language effort, we recommend creating a new organization for your language effort. This will allow you to keep all of your language effort data in one place. We suggest naming this organization \"DIBT-{language}\" where `{language}` is the name of your language. For example, if you are working on the language \"Spanish\", you would name your organization \"DIBT-Spanish\". This will make it easier for us to track all of the DIBT language efforts.\n",
         "\n",
         "You can use this link to create a new organization on the Hub: [https://huggingface.co/organizations/new](https://huggingface.co/organizations/new).\n",
         "\n",
@@ -416,7 +416,7 @@
         "id": "NoT7dfCjVTxe"
       },
       "source": [
-        "We now need to factory reset the Space to ensure all of the above changes register"
+        "We now need to factory reset the Space to ensure all of the above changes register."
       ]
     },
     {


### PR DESCRIPTION
Add the Russian-langauge DIBT project to the list of active projects, a different expression of the `language` variable in the documentation (which due to GitHub-flavored Markdown rules is currently omitted)  and a single period I found missing just because of an incidental re-reading.

Wishing you well 🤗 