### PR TITLE
enable color selection for pie chart

### DIFF
--- a/prompt_translation/dashboard_template/app.py
+++ b/prompt_translation/dashboard_template/app.py
@@ -108,16 +108,19 @@ def donut_chart_total() -> alt.Chart:
         {
             "values": [annotated_records, pending_records],
             "category": [ANNOTATED, PENDING],
-            "colors": ["#4CAF50", "#757575"],  # Green for Completed, Grey for Remaining
+            "colors": ["#4682b4", "#e68c39"],  # Blue for Completed, Orange for Remaining
         }
     )
+
+    domain = source['category'].tolist()
+    range_ = source['colors'].tolist()
 
     base = alt.Chart(source).encode(
         theta=alt.Theta("values:Q", stack=True),
         radius=alt.Radius(
             "values", scale=alt.Scale(type="sqrt", zero=True, rangeMin=20)
         ),
-        color=alt.Color("category:N", legend=alt.Legend(title=CATEGORY)),
+    color=alt.Color(field="category", type="nominal", scale=alt.Scale(domain=domain, range=range_), legend=alt.Legend(title=CATEGORY)),
     )
 
     c1 = base.mark_arc(innerRadius=20, stroke="#fff")


### PR DESCRIPTION
## Summary

@ignacioct, thank you for putting together such a straightforward dashboard build. Please note changed code, we declare colors which aren't actually used by dash.

**Goal of PR**: enable users to select custom colors for their Donut Chart.

## More info:
- I've updated default colors to be the same as they were before, so new deploys won't change unless user configured colors.

## Follow up
If PR is merged and there is appetite to do so, I am happy to build in the option to modify colors of remaining visualizations.

🤗 