### PR TITLE
Add more warnings about losing data when persisent storage is not enabled

### DIFF
--- a/prompt_translation/01_setup_prompt_translation_space.ipynb
+++ b/prompt_translation/01_setup_prompt_translation_space.ipynb
@@ -14,6 +14,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div style=\"background-color: #f44336; padding: 20px; color: white; font-size: 24px; font-weight: bold; border-radius: 10px;\">\n",
+    "⚠️ WARNING! ⚠️<br>\n",
+    "It is very important that you ensure that you don't carry out any annotations using the Argilla Space until you have confirmation that persistent storage is enabled. If you carry out annotations before this, you will very likely loose your work.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# 1. Creating a Prompt Translation Argilla Space"
    ]
   },
@@ -437,6 +447,16 @@
     "from huggingface_hub import restart_space\n",
     "\n",
     "restart_space(to_id, factory_reboot=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style=\"background-color: #f44336; padding: 20px; color: white; font-size: 24px; font-weight: bold; border-radius: 10px;\">\n",
+    "⚠️ WARNING! ⚠️<br>\n",
+    "It is very important that you ensure that you don't carry out any annotations using the Argilla Space until you receive a confirmation message on Discord that persistent storage is enabled. If you carry out annotations before this, your work will be deleted or lost when we do the upgrade. We will not be able to restore any data lost in this way.\n",
+    "</div>"
    ]
   },
   {

--- a/prompt_translation/01_setup_prompt_translation_space.ipynb
+++ b/prompt_translation/01_setup_prompt_translation_space.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "<div style=\"background-color: #f44336; padding: 20px; color: white; font-size: 24px; font-weight: bold; border-radius: 10px;\">\n",
     "<h1> ⚠️ WARNING! ⚠️<br> </h1>\n",
-    "It is very important that you ensure that you don't carry out any annotations using the Argilla Space until you have confirmation that persistent storage is enabled. If you carry out annotations before this, you will very likely loose your work.\n",
+    "It is very important that you ensure that you don't carry out any annotations using the Argilla Space until you have confirmation that persistent storage is enabled. If you carry out annotations before this, you will very likely lose your work.\n",
     "</div>"
    ]
   },

--- a/prompt_translation/01_setup_prompt_translation_space.ipynb
+++ b/prompt_translation/01_setup_prompt_translation_space.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "source": [
     "<div style=\"background-color: #f44336; padding: 20px; color: white; font-size: 24px; font-weight: bold; border-radius: 10px;\">\n",
-    "⚠️ WARNING! ⚠️<br>\n",
+    "<h1> ⚠️ WARNING! ⚠️<br> </h1>\n",
     "It is very important that you ensure that you don't carry out any annotations using the Argilla Space until you have confirmation that persistent storage is enabled. If you carry out annotations before this, you will very likely loose your work.\n",
     "</div>"
    ]
@@ -454,7 +454,7 @@
    "metadata": {},
    "source": [
     "<div style=\"background-color: #f44336; padding: 20px; color: white; font-size: 24px; font-weight: bold; border-radius: 10px;\">\n",
-    "⚠️ WARNING! ⚠️<br>\n",
+    "<h1>⚠️ WARNING! ⚠️<br> </h1>\n",
     "It is very important that you ensure that you don't carry out any annotations using the Argilla Space until you receive a confirmation message on Discord that persistent storage is enabled. If you carry out annotations before this, your work will be deleted or lost when we do the upgrade. We will not be able to restore any data lost in this way.\n",
     "</div>"
    ]

--- a/prompt_translation/02_upload_prompt_translation_data.ipynb
+++ b/prompt_translation/02_upload_prompt_translation_data.ipynb
@@ -14,6 +14,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div style=\"background-color: #f44336; padding: 20px; color: white; font-size: 24px; font-weight: bold; border-radius: 10px;\">\n",
+    "⚠️ WARNING! ⚠️<br>\n",
+    "It is very important that you ensure that you don't carry out any annotations using the Argilla Space until you receive a confirmation message on Discord that persistent storage is enabled. If you carry out annotations before this, your work will be deleted or lost when we do the upgrade. We will not be able to restore any data lost in this way.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# 2. Uploading prompts to be translated to an Argilla Space \n",
     "\n",
     "This notebook focuses on the steps involved in uploading prompts to be translated to an Argilla Space. It assumes you have already created an Argilla Space and have the Space ID and API key. If you haven't created an Argilla Space yet, please refer to the previous notebooks and the overall README for instructions on how to do so."

--- a/prompt_translation/02_upload_prompt_translation_data.ipynb
+++ b/prompt_translation/02_upload_prompt_translation_data.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "source": [
     "<div style=\"background-color: #f44336; padding: 20px; color: white; font-size: 24px; font-weight: bold; border-radius: 10px;\">\n",
-    "⚠️ WARNING! ⚠️<br>\n",
+    "<h1> ⚠️ WARNING! ⚠️<br></h1>\n",
     "It is very important that you ensure that you don't carry out any annotations using the Argilla Space until you receive a confirmation message on Discord that persistent storage is enabled. If you carry out annotations before this, your work will be deleted or lost when we do the upgrade. We will not be able to restore any data lost in this way.\n",
     "</div>"
    ]

--- a/prompt_translation/README.md
+++ b/prompt_translation/README.md
@@ -39,6 +39,12 @@ To get started, you will need to set up a Hub organization and create an Argilla
 - This [notebook](./01_setup_prompt_translation_space.ipynb) (<a href="https://colab.research.google.com/github/huggingface/data-is-better-together/blob/main/prompt_translation/01_setup_prompt_translation_space.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>) will guide you through the process of setting up a Hub organization and creating an Argilla Space for your language.
 - This [notebook](./02_upload_prompt_translation_data.ipynb) (<a href="https://colab.research.google.com/github/huggingface/data-is-better-together/blob/main/prompt_translation/02_upload_prompt_translation_data.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>) will guide you through the process of uploading the prompt translation data to your Argilla Space and optionally pre-translating the prompts using Hugging Face models. It will also show you how to create a dashboard to monitor the progress of the translation task!
 
+
+<div style="background-color: #f44336; padding: 20px; color: white; font-size: 24px; font-weight: bold; border-radius: 10px;">
+⚠️ WARNING! ⚠️<br>
+Ensure that you don't carry out any annotations using the Argilla Space until you receive a confirmation message on Discord that persistent storage is enabled. If you carry out annotations before this, your work will be deleted or lost when we do the upgrade. We will not be able to restore any data lost in this way.
+</div>
+
 #### Gather a community of people and begin translating!
 
 Once an Argilla Space is created, anyone with a Hugging Face login can log in to an account and begin contributing to the translations. If no existing communities are focused on ML for your language, you may want to create a thread in the DIBT Discord channel to discuss with others. This might also lead to some excellent follow-up project ideas!

--- a/prompt_translation/README.md
+++ b/prompt_translation/README.md
@@ -40,10 +40,9 @@ To get started, you will need to set up a Hub organization and create an Argilla
 - This [notebook](./02_upload_prompt_translation_data.ipynb) (<a href="https://colab.research.google.com/github/huggingface/data-is-better-together/blob/main/prompt_translation/02_upload_prompt_translation_data.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>) will guide you through the process of uploading the prompt translation data to your Argilla Space and optionally pre-translating the prompts using Hugging Face models. It will also show you how to create a dashboard to monitor the progress of the translation task!
 
 
-<div style="background-color: #f44336; padding: 20px; color: white; font-size: 24px; font-weight: bold; border-radius: 10px;">
 ⚠️ WARNING! ⚠️<br>
 Ensure that you don't carry out any annotations using the Argilla Space until you receive a confirmation message on Discord that persistent storage is enabled. If you carry out annotations before this, your work will be deleted or lost when we do the upgrade. We will not be able to restore any data lost in this way.
-</div>
+
 
 #### Gather a community of people and begin translating!
 


### PR DESCRIPTION
This PR makes the warnings about enabling persistent storage more visually strong i.e. rendered as 

<img width="929" alt="Screenshot 2024-03-25 at 17 30 27" src="https://github.com/huggingface/data-is-better-together/assets/8995957/307f446a-39a3-4d4a-830a-35c89acbeab9">

and 

<img width="1053" alt="Screenshot 2024-03-25 at 17 30 43" src="https://github.com/huggingface/data-is-better-together/assets/8995957/0ba6333f-8cc6-49be-8a12-3f126d10d4d5">
